### PR TITLE
Fix alt text for newspaper image

### DIFF
--- a/content/blog/things-to-add.md
+++ b/content/blog/things-to-add.md
@@ -4,7 +4,7 @@ slug: to-add
 excerpt: List of items that still need to be built
 feature_image:
   url: /images/uploads/image_fx_-11-.jpeg
-  alt: A bear reading a news paper in a lounge chair
+  alt: A bear reading a newspaper in a lounge chair
 html_content: |-
   ## Things that I still need to build
 


### PR DESCRIPTION
## Summary
- correct minor typo in feature image alt text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68427afd7a74832ab2d0e8aba5e842a8