### PR TITLE
Fix rebuild logic in build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const matter = require('gray-matter');
 const marked = require('marked');
 require('dotenv').config();
@@ -468,7 +469,8 @@ Enjoy blogging!
   
   // Run the build again to process the sample content
   console.log('Re-running build to process sample content...');
-  require('./build.js');
+  // Spawn a new Node process to rerun this script because require() is cached
+  spawnSync('node', [__filename], { stdio: 'inherit' });
   return;
 }
 


### PR DESCRIPTION
## Summary
- fix rerunning build.js when sample content is created

## Testing
- `node --check build.js`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_684279332208832abe52024d4ae7763f